### PR TITLE
Fix V3127

### DIFF
--- a/viadflib/TravelTime/LatLng.cs
+++ b/viadflib/TravelTime/LatLng.cs
@@ -49,7 +49,7 @@ namespace viadflib.TravelTime
         public double DistanceInKmTo(LatLng other)
         {
             double distanceLat = Math.Abs(Lat - other.Lat) * _latKmLookup[(int)Lat];
-            double distanceLng = Math.Abs(Lng - other.Lng) * _lngKmLookup[(int)Lat];
+            double distanceLng = Math.Abs(Lng - other.Lng) * _lngKmLookup[(int)Lng];
 
             return Math.Sqrt(distanceLat * distanceLat + distanceLng * distanceLng);
         }
@@ -57,7 +57,7 @@ namespace viadflib.TravelTime
         public double DistanceInKmSquaredTo(LatLng other)
         {
             double distanceLat = Math.Abs(Lat - other.Lat) * _latKmLookup[(int)Lat];
-            double distanceLng = Math.Abs(Lng - other.Lng) * _lngKmLookup[(int)Lat];
+            double distanceLng = Math.Abs(Lng - other.Lng) * _lngKmLookup[(int)Lng];
 
             return distanceLat * distanceLat + distanceLng * distanceLng;
         }


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

### V3127

- Two similar code fragments were found. Perhaps, this is a typo and 'Lng' variable should be used instead of 'Lat' viadflib LatLng.cs 52

- Two similar code fragments were found. Perhaps, this is a typo and 'Lng' variable should be used instead of 'Lat' viadflib LatLng.cs 60